### PR TITLE
Allow the path and url generating functions to take a single argument

### DIFF
--- a/src/clojure/clojurewerkz/route_one/core.clj
+++ b/src/clojure/clojurewerkz/route_one/core.clj
@@ -92,9 +92,9 @@
   [^clojure.lang.Symbol n ^String pattern]
   `(do (def ~(symbol (format "%s-template" n)) ~pattern)
        (defn ~(symbol (format "%s-path" n)) [& data#]
-         (path-for ~pattern (apply hash-map data#)))
+         (path-for ~pattern (if (= 1 (count data#)) (first data#) (apply hash-map data#))))
        (defn ~(symbol (format "%s-url" n)) [& data#]
-         (url-for ~pattern (apply hash-map data#)))))
+         (url-for ~pattern (if (= 1 (count data#)) (first data#) (apply hash-map data#))))))
 
 (defmacro with-base-url
   [s & body]

--- a/test/clojurewerkz/route_one/core_test.clj
+++ b/test/clojurewerkz/route_one/core_test.clj
@@ -40,7 +40,10 @@
     (is (= "/docs/cat/a-title?name=Marmalade"
            (path-for "/docs/:category/:title" {:category "cat" :title "a-title" :name "Marmalade"})))
     (is (= "/docs/cat/a-title?name=Marmalade"
-           (category-documents-path :category "cat" :title "a-title" :name "Marmalade")))))
+           (category-documents-path :category "cat" :title "a-title" :name "Marmalade"))))
+  (testing "generation of name routes with single map argument"
+    (is (= "/docs/cat/a-title?name=Marmalade"
+           (category-documents-path {:category "cat" :title "a-title" :name "Marmalade"})))))
 
 (deftest test-url-generation
   (with-base-url "http://giove.local"
@@ -64,7 +67,10 @@
              (about-url :name "Joe Bloggs"))))
     (testing "generation of URL with path prefix, segments, and query string"
       (is (= "https://giove.local/path/prefix/docs/cat/a-title?name=Marmalade"
-             (category-documents-url :category "cat" :title "a-title" :name "Marmalade"))))))
+             (category-documents-url :category "cat" :title "a-title" :name "Marmalade"))))
+    (testing "generation or URL wih single map argument"
+      (is (= "https://giove.local/path/prefix/docs/cat/a-title?name=Marmalade"
+             (category-documents-url {:category "cat" :title "a-title" :name "Marmalade"}))))))
 
 (deftest test-templates
   (is (= "/about" about-template))


### PR DESCRIPTION
I quite often find myself wanting to call the `...-url` and `...-path` functions with a map, e.g. when a row is pulled from a database. This patch allows you to pass such a map as a single argument to these functions, while also preserving the old interface.
