### PR TITLE
WIP (don't merge!): First stab at compojure-like context feature

### DIFF
--- a/src/clojure/clojurewerkz/route_one/compojure.clj
+++ b/src/clojure/clojurewerkz/route_one/compojure.clj
@@ -2,41 +2,37 @@
   (:require [compojure.core :as compojure]
             [clojurewerkz.route-one.core :as route-one]))
 
+(def ^{:dynamic true} *route-prefix* nil)
+
+(defmacro handler-with-route [req-handler name path args body]
+  `(do
+     (let [route-path# (if *route-prefix* (str *route-prefix* ~path) ~path)]
+       (route-one/defroute ~(symbol (str name)) route-path#))
+     (~req-handler ~path ~args ~@body)))
+
 (defmacro GET "Generate a GET route."
   [name path args & body]
-  `(do
-     (route-one/defroute ~(symbol (str name)) ~path)
-     (compojure/GET ~path ~args ~@body)))
+  `(handler-with-route compojure.core/GET ~name ~path ~args ~body))
 
 (defmacro POST "Generate a POST route."
   [name path args & body]
-  `(do
-     (route-one/defroute ~(symbol (str name)) ~path)
-     (compojure/POST ~path ~args ~@body)))
+  `(handler-with-route compojure.core/POST ~name ~path ~args ~body))
 
 (defmacro PUT "Generate a PUT route."
   [name path args & body]
-  `(do
-     (route-one/defroute ~(symbol (str name)) ~path)
-     (compojure/PUT ~path ~args ~@body)))
+  `(handler-with-route compojure.core/PUT ~name ~path ~args ~body))
 
 (defmacro OPTIONS "Generate a OPTIONS route."
   [name path args & body]
-  `(do
-     (route-one/defroute ~(symbol (str name)) ~path)
-     (compojure/OPTIONS ~path ~args ~@body)))
+  `(handler-with-route compojure.core/OPTIONS ~name ~path ~args ~body))
 
 (defmacro HEAD "Generate a HEAD route."
   [name path args & body]
-  `(do
-     (route-one/defroute ~(symbol (str name)) ~path)
-     (compojure/HEAD ~path ~args ~@body)))
+  `(handler-with-route compojure.core/HEAD ~name ~path ~args ~body))
 
 (defmacro PATCH "Generate a PATCH route."
   [name path args & body]
-  `(do
-     (route-one/defroute ~(symbol (str name)) ~path)
-     (compojure/PATCH ~path ~args ~@body)))
+  `(handler-with-route compojure.core/PATCH ~name ~path ~args ~body))
 
 (defmacro ANY "Generate a ANY route."
   [name path args & body]
@@ -48,3 +44,13 @@
   "Generate a Catch-all fallback route"
   [args & body]
   `(compojure/ANY "*" ~args ~@body))
+
+(defmacro context [path args & routes]
+  `(let [path# (if *route-prefix* (str *route-prefix* ~path) ~path)]
+     (binding [*route-prefix* path#]
+       (let [routes# (compojure/routes ~@routes)]
+         (compojure/context ~path ~args routes#)))))
+
+(defmacro routes [& handlers]
+  `(fn []
+     (compojure/routes ~@handlers)))

--- a/src/clojure/clojurewerkz/route_one/compojure.clj
+++ b/src/clojure/clojurewerkz/route_one/compojure.clj
@@ -47,9 +47,9 @@
   [args & body]
   `(compojure/ANY "*" ~args ~@body))
 
-(defn- evaluate-thunk
+(defn ^{:private true} evaluate-route-thunk
   [form]
-  `(let [routes-thunk?# (:routes-thunk? (meta ~form))]
+  `(let [routes-thunk?# (::routes-thunk? (meta ~form))]
      (if routes-thunk?#
        (~form)
        ~form)))
@@ -58,8 +58,8 @@
   [& handlers]
   `(vary-meta
      (fn []
-       (compojure/routes ~@(map evaluate-thunk handlers)))
-     assoc :routes-thunk? true))
+       (compojure/routes ~@(map evaluate-route-thunk handlers)))
+     assoc ::routes-thunk? true))
 
 (defmacro context
   [path args & routes]

--- a/src/clojure/clojurewerkz/route_one/compojure.clj
+++ b/src/clojure/clojurewerkz/route_one/compojure.clj
@@ -4,7 +4,8 @@
 
 (def ^{:dynamic true} *route-prefix* nil)
 
-(defmacro handler-with-route [req-handler name path args body]
+(defmacro handler-with-route
+  [req-handler name path args body]
   `(do
      (let [route-path# (if *route-prefix* (str *route-prefix* ~path) ~path)]
        (route-one/defroute ~(symbol (str name)) route-path#))
@@ -45,12 +46,14 @@
   [args & body]
   `(compojure/ANY "*" ~args ~@body))
 
-(defmacro context [path args & routes]
+(defmacro context
+  [path args & routes]
   `(let [path# (if *route-prefix* (str *route-prefix* ~path) ~path)]
      (binding [*route-prefix* path#]
        (let [routes# (compojure/routes ~@routes)]
          (compojure/context ~path ~args routes#)))))
 
-(defmacro routes [& handlers]
+(defmacro routes
+  [& handlers]
   `(fn []
      (compojure/routes ~@handlers)))

--- a/src/clojure/clojurewerkz/route_one/compojure.clj
+++ b/src/clojure/clojurewerkz/route_one/compojure.clj
@@ -71,4 +71,4 @@
 (defmacro defroutes
   [name & routes]
   (let [[name routes] (name-with-attributes name routes)]
-    `(def ~name (routes ~@routes))))
+    `(def ~name ((routes ~@routes)))))

--- a/test/clojurewerkz/route_one/compojure_test.clj
+++ b/test/clojurewerkz/route_one/compojure_test.clj
@@ -1,4 +1,5 @@
 (ns clojurewerkz.route-one.compojure-test
+  (:require [compojure.core :as compojure])
   (:use clojure.test
         clojurewerkz.route-one.compojure))
 
@@ -21,3 +22,16 @@
                        "res")]
       (is (= "res" (:body (handler
                            (fake-request :get (users-index-path) {:get :params}))))))))
+
+(deftest nested-routes-test
+  (testing "Handler in context"
+    ((context "/user/current" []
+               (GET user-profile "/profile" {:keys [params]} "res"))
+      (fake-request :get "/user/current/profile" {:get :params}))
+    (is (= (user-profile-path) "/user/current/profile")))
+  (testing "Handler in nested contexts"
+    (let [inner (routes (context "/tasks" []
+                          (GET user-add-task "/add" {:keys [params]} "res")))
+          outer (context "/user/current" [] (inner))]
+      (is (= "res" (:body (outer (fake-request :get "/user/current/tasks/add" {:get :params})))))
+      (is (= (user-add-task-path) "/user/current/tasks/add")))))

--- a/test/clojurewerkz/route_one/compojure_test.clj
+++ b/test/clojurewerkz/route_one/compojure_test.clj
@@ -32,6 +32,6 @@
   (testing "Handler in nested contexts"
     (let [inner (routes (context "/tasks" []
                           (GET user-add-task "/add" {:keys [params]} "res")))
-          outer (context "/user/current" [] (inner))]
+          outer (context "/user/current" [] inner)]
       (is (= "res" (:body (outer (fake-request :get "/user/current/tasks/add" {:get :params})))))
       (is (= (user-add-task-path) "/user/current/tasks/add")))))


### PR DESCRIPTION
This is my first attempt at adding support for a compojure style context. I've spent more time on it than I'd be willing to admit - mainly due to my complete ineptitude when it comes to dealing with macro writing which I hardly do in my own code. The main addition is `context` macro that evaluates routes early with bindings changed accordingly before passing them down to compojure's context. Due to problems in dealing with nested contexts, I had to create a workaround for separately defining subroutes which then get passed into existing context - in the form of `routes` macro, which creates a thunk that has to be explicitly evaluated in the scope of context in which it is embedded. The solution isn't thoroughly tested. However, I wanted to get it out because maybe I'm doing something border-line idiotic while not being aware of it.

This PR is related to issue #17.
